### PR TITLE
Laravel 5.4 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,10 @@
   ],
   "require": {
     "php": ">=5.5.9",
-    "illuminate/support": "5.2.*|5.3.*",
-    "illuminate/config": "5.2.*|5.3.*",
-    "illuminate/view": "5.2.*|5.3.*",
-    "laravelcollective/html": "5.2.*|5.3.*"
+    "illuminate/support": "5.2.*|5.3.*|5.4.*",
+    "illuminate/config": "5.2.*|5.3.*|5.4.*",
+    "illuminate/view": "5.2.*|5.3.*|5.4.*",
+    "laravelcollective/html": "5.2.*|5.3.*|5.4.*"
   },
   "require-dev": {
     "phpunit/phpunit": "~4",

--- a/src/MenusServiceProvider.php
+++ b/src/MenusServiceProvider.php
@@ -40,7 +40,8 @@ class MenusServiceProvider extends ServiceProvider
     {
         $this->registerHtmlPackage();
 
-        $this->app['menus'] = $this->app->share(function ($app) {
+        $this->app->singleton('menus', function ($app)
+        {
             return new Menu($app['view'], $app['config']);
         });
     }


### PR DESCRIPTION
Added support for Laravel 5.4 ( relates to #2 ).

It seems, that laravelcollective/html now supports Laravel 5.4.
See: https://github.com/LaravelCollective/html/releases