### PR TITLE
Fix fatal error when there is an empty dropdown on Laravel 5.8

### DIFF
--- a/src/MenuItem.php
+++ b/src/MenuItem.php
@@ -325,7 +325,10 @@ class MenuItem implements ArrayableContract
         if ($this->route !== null) {
             return route($this->route[0], $this->route[1]);
         }
-
+        
+        if(empty($this->url))
+            return url("/#");
+        
         return url($this->url);
     }
 


### PR DESCRIPTION
This is a quick fix, since the helper method url() no longer accepts null or empty values, it throws a fatal error.

Quick fix:
Permissible: add a hashtag link as a default URL for any item, including dropdowns.  **(this is the one on this pull request)**
Enforcing: Throw a custom exception letting us know that there is an empty dropdown. (This will still break the code when an empty dropdown is rendered.

Long Fix:
Change how a submenu is identified as one since right now we are counting the number of children and on empty dropdowns, there are no children. 