### PR TITLE
use Repository contract as type hint

### DIFF
--- a/src/Menu.php
+++ b/src/Menu.php
@@ -4,7 +4,7 @@ namespace Nwidart\Menus;
 
 use Closure;
 use Countable;
-use Illuminate\Config\Repository;
+use Illuminate\Contracts\Config\Repository;
 use Illuminate\View\Factory;
 
 class Menu implements Countable

--- a/src/MenuBuilder.php
+++ b/src/MenuBuilder.php
@@ -3,7 +3,7 @@
 namespace Nwidart\Menus;
 
 use Countable;
-use Illuminate\Config\Repository;
+use Illuminate\Contracts\Config\Repository;
 use Illuminate\View\Factory as ViewFactory;
 
 class MenuBuilder implements Countable


### PR DESCRIPTION
Some user might extending the default laravel config by implementing the `\Illuminate\Contracts\Config\Repository` interface, like this package (https://github.com/illuminatech/config)

By updating to Repository contract, any users that extending the default laravel config are able to use this package.