### PR TITLE
Replace array and str helper

### DIFF
--- a/src/MenuBuilder.php
+++ b/src/MenuBuilder.php
@@ -4,6 +4,7 @@ namespace Nwidart\Menus;
 
 use Countable;
 use Illuminate\Contracts\Config\Repository;
+use Illuminate\Support\Arr;
 use Illuminate\View\Factory as ViewFactory;
 
 class MenuBuilder implements Countable
@@ -351,8 +352,8 @@ class MenuBuilder implements Countable
         if (func_num_args() == 3) {
             $arguments = func_get_args();
 
-            $title = array_get($arguments, 0);
-            $attributes = array_get($arguments, 2);
+            $title = Arr::get($arguments, 0);
+            $attributes = Arr::get($arguments, 2);
 
             $properties = compact('title', 'attributes');
         }
@@ -382,9 +383,9 @@ class MenuBuilder implements Countable
             $arguments = func_get_args();
 
             return $this->add([
-                'route' => [array_get($arguments, 0), array_get($arguments, 2)],
-                'title' => array_get($arguments, 1),
-                'attributes' => array_get($arguments, 3),
+                'route' => [Arr::get($arguments, 0), Arr::get($arguments, 2)],
+                'title' => Arr::get($arguments, 1),
+                'attributes' => Arr::get($arguments, 3),
             ]);
         }
 
@@ -428,9 +429,9 @@ class MenuBuilder implements Countable
             $arguments = func_get_args();
 
             return $this->add([
-                'url' => $this->formatUrl(array_get($arguments, 0)),
-                'title' => array_get($arguments, 1),
-                'attributes' => array_get($arguments, 2),
+                'url' => $this->formatUrl(Arr::get($arguments, 0)),
+                'title' => Arr::get($arguments, 1),
+                'attributes' => Arr::get($arguments, 2),
             ]);
         }
 

--- a/src/MenuItem.php
+++ b/src/MenuItem.php
@@ -7,6 +7,7 @@ use Collective\Html\HtmlFacade as HTML;
 use Illuminate\Contracts\Support\Arrayable as ArrayableContract;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Request;
+use Illuminate\Support\Str;
 
 /**
  * @property string url
@@ -101,7 +102,7 @@ class MenuItem implements ArrayableContract
      */
     protected static function getRandomName(array $attributes)
     {
-        return substr(md5(array_get($attributes, 'title', str_random(6))), 0, 5);
+        return substr(md5(Arr::get($attributes, 'title', Str::random(6))), 0, 5);
     }
 
     /**
@@ -161,8 +162,8 @@ class MenuItem implements ArrayableContract
         if (func_num_args() === 3) {
             $arguments = func_get_args();
 
-            $title = array_get($arguments, 0);
-            $attributes = array_get($arguments, 2);
+            $title = Arr::get($arguments, 0);
+            $attributes = Arr::get($arguments, 2);
 
             $properties = compact('title', 'attributes');
         }
@@ -192,9 +193,9 @@ class MenuItem implements ArrayableContract
             $arguments = func_get_args();
 
             return $this->add([
-                'route' => [array_get($arguments, 0), array_get($arguments, 2)],
-                'title' => array_get($arguments, 1),
-                'attributes' => array_get($arguments, 3),
+                'route' => [Arr::get($arguments, 0), Arr::get($arguments, 2)],
+                'title' => Arr::get($arguments, 1),
+                'attributes' => Arr::get($arguments, 3),
             ]);
         }
 
@@ -218,9 +219,9 @@ class MenuItem implements ArrayableContract
             $arguments = func_get_args();
 
             return $this->add([
-                'url' => array_get($arguments, 0),
-                'title' => array_get($arguments, 1),
-                'attributes' => array_get($arguments, 2),
+                'url' => Arr::get($arguments, 0),
+                'title' => Arr::get($arguments, 1),
+                'attributes' => Arr::get($arguments, 2),
             ]);
         }
 
@@ -507,7 +508,7 @@ class MenuItem implements ArrayableContract
      */
     public function getActiveAttribute()
     {
-        return array_get($this->attributes, 'active');
+        return Arr::get($this->attributes, 'active');
     }
 
     /**
@@ -517,7 +518,7 @@ class MenuItem implements ArrayableContract
      */
     public function getInactiveAttribute()
     {
-        return array_get($this->attributes, 'inactive');
+        return Arr::get($this->attributes, 'inactive');
     }
 
     /**

--- a/src/Presenters/Bootstrap/SidebarMenuPresenter.php
+++ b/src/Presenters/Bootstrap/SidebarMenuPresenter.php
@@ -2,6 +2,7 @@
 
 namespace Nwidart\Menus\Presenters\Bootstrap;
 
+use Illuminate\Support\Str;
 use Nwidart\Menus\Presenters\Presenter;
 
 class SidebarMenuPresenter extends Presenter
@@ -82,7 +83,7 @@ class SidebarMenuPresenter extends Presenter
      */
     public function getMenuWithDropDownWrapper($item)
     {
-        $id = str_random();
+        $id = Str::random();
 
         return '
 		<li class="' . $this->getActiveStateOnChild($item) . ' panel panel-default" id="dropdown">


### PR DESCRIPTION
By default both `array_*` and `str_*` are no longer supported helper functions in Laravel 6 and not all user will import the new `laravel/helpers` package.