### PR TITLE
Fix for dropdown() function.

### DIFF
--- a/src/MenuBuilder.php
+++ b/src/MenuBuilder.php
@@ -349,7 +349,8 @@ class MenuBuilder implements Countable
     {
         $properties = compact('title', 'order', 'attributes');
 
-        if (func_num_args() == 3) {
+        if (func_num_args() == 3 && is_array($order)) {
+            // $attributes passed in as 3rd parameter
             $arguments = func_get_args();
 
             $title = Arr::get($arguments, 0);

--- a/src/MenuItem.php
+++ b/src/MenuItem.php
@@ -159,7 +159,8 @@ class MenuItem implements ArrayableContract
     {
         $properties = compact('title', 'order', 'attributes');
 
-        if (func_num_args() === 3) {
+        if (func_num_args() === 3 && is_array($order)) {
+            // $attributes passed in as third parameter
             $arguments = func_get_args();
 
             $title = Arr::get($arguments, 0);


### PR DESCRIPTION
if three arguments are passed in to dropdown(), code was assuming that 3rd arguments is attributes and assigning the $order parameter to $attributes. When there are three arguments, 3rd argument could really be order with attributes not passed in at all.

Fixes #67