### PR TITLE
dropdown() bug fix and improvement - parent menu item can have link and other properties

### DIFF
--- a/src/MenuBuilder.php
+++ b/src/MenuBuilder.php
@@ -349,7 +349,8 @@ class MenuBuilder implements Countable
     {
         $properties = compact('title', 'order', 'attributes');
 
-        if (func_num_args() == 3) {
+        if (func_num_args() == 3 && is_array($order)) {
+            // $attributes passed in as 3rd parameter
             $arguments = func_get_args();
 
             $title = Arr::get($arguments, 0);

--- a/src/MenuBuilder.php
+++ b/src/MenuBuilder.php
@@ -339,9 +339,14 @@ class MenuBuilder implements Countable
     /**
      * Create new menu with dropdown.
      *
-     * @param $title_or_properties  can give all properties in one argument, or give title separately
+     * @param $title_or_properties  can give all properties in one argument
+     *    or give title as string title separately
      *
      * @param callable $callback callback to add submenu items
+     *
+     * @param int $order  
+     *
+     * @param array $attributes	
      *
      * @return $this
      */

--- a/src/MenuBuilder.php
+++ b/src/MenuBuilder.php
@@ -339,24 +339,41 @@ class MenuBuilder implements Countable
     /**
      * Create new menu with dropdown.
      *
-     * @param $title
-     * @param callable $callback
-     * @param array    $attributes
+     * @param $title_or_properties  can give all properties in one argument, or give title separately
+     *
+     * @param callable $callback callback to add submenu items
      *
      * @return $this
      */
-    public function dropdown($title, \Closure $callback, $order = null, array $attributes = array())
+
+    public function dropdown($title_or_properties, \Closure $callback, $order = null, array $attributes = array())
     {
-        $properties = compact('title', 'order', 'attributes');
+        if (is_array($title_or_properties)) {
 
-        if (func_num_args() == 3 && is_array($order)) {
-            // $attributes passed in as 3rd parameter
-            $arguments = func_get_args();
+            if (($title_or_properties['attributes']??null) === null)
+            {
+               $title_or_properties['attributes'] = [];
+            }
 
-            $title = Arr::get($arguments, 0);
-            $attributes = Arr::get($arguments, 2);
+            $properties = $title_or_properties;
+        }
+        else
+        {
+            $title = $title_or_properties;
 
-            $properties = compact('title', 'attributes');
+            // backwards compatible with previous code that assumes that 
+            // if three args are passed in, third must be attributes
+
+            if (func_num_args() === 3 && is_array($order)) {
+               $attributes = $order;
+               $properties = compact('title', 'attributes');
+            }
+            else
+            {
+               $properties = compact('title', 'order', 'attributes');
+            }
+
+            $properties = compact('title', 'order', 'attributes');
         }
 
         $item = MenuItem::make($properties);

--- a/src/MenuItem.php
+++ b/src/MenuItem.php
@@ -159,7 +159,8 @@ class MenuItem implements ArrayableContract
     {
         $properties = compact('title', 'order', 'attributes');
 
-        if (func_num_args() === 3) {
+        if (func_num_args() === 3 && is_array($order)) {
+            // $attributes passed in as third parameter
             $arguments = func_get_args();
 
             $title = Arr::get($arguments, 0);

--- a/src/MenuItem.php
+++ b/src/MenuItem.php
@@ -150,13 +150,17 @@ class MenuItem implements ArrayableContract
     /**
      * Register new child menu with dropdown.
      *
-     * @param $title_or_properties  can give all properties in one argument, or give title separately
+     * @param $title_or_properties  can give all properties in one argument
+     *    or give title as string title separately
      *
      * @param callable $callback callback to add submenu items
      *
+     * @param int $order
+     *
+     * @param array $attributes
+     *
      * @return $this
      */
-
     public function dropdown($title_or_properties, \Closure $callback, $order = 0, array $attributes = array())
     {
         if (is_array($title_or_properties)) {

--- a/src/MenuItem.php
+++ b/src/MenuItem.php
@@ -150,23 +150,39 @@ class MenuItem implements ArrayableContract
     /**
      * Register new child menu with dropdown.
      *
-     * @param $title
-     * @param callable $callback
+     * @param $title_or_properties  can give all properties in one argument, or give title separately
+     *
+     * @param callable $callback callback to add submenu items
      *
      * @return $this
      */
-    public function dropdown($title, \Closure $callback, $order = 0, array $attributes = array())
+
+    public function dropdown($title_or_properties, \Closure $callback, $order = 0, array $attributes = array())
     {
-        $properties = compact('title', 'order', 'attributes');
+        if (is_array($title_or_properties)) {
 
-        if (func_num_args() === 3 && is_array($order)) {
-            // $attributes passed in as third parameter
-            $arguments = func_get_args();
+            if (($title_or_properties['attributes']??null) === null)
+            {
+               $title_or_properties['attributes'] = [];
+            }
 
-            $title = Arr::get($arguments, 0);
-            $attributes = Arr::get($arguments, 2);
+            $properties = $title_or_properties;
+        }
+        else
+        {
+            $title = $title_or_properties;
 
-            $properties = compact('title', 'attributes');
+            // backwards compatible with previous code that assumes that 
+            // if three args are passed in, third must be attributes
+
+            if (func_num_args() === 3 && is_array($order)) {
+               $attributes = $order;
+               $properties = compact('title', 'attributes');
+            }
+            else
+            {
+               $properties = compact('title', 'order', 'attributes');
+            }
         }
 
         $child = static::make($properties);


### PR DESCRIPTION
Can now pass in properties for parent menu item in dropdown() instead of just title, order and attributes.  That way, the parent menu item can link to somewhere as well.

if three arguments are passed in to dropdown(), code was assuming that 3rd arguments is attributes and assigning the $order parameter to $attributes. When there are three arguments, 3rd argument could really be order with attributes not passed in at all.

Fixes #68 
Fixes #67 
